### PR TITLE
Retry after failed login attempt

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -7,14 +7,6 @@ function MerchantAPI() {
   this.cache = new WalletCache();
 }
 
-MerchantAPI.prototype.login = function (guid, options) {
-  var addDeprecationWarning = function (response) {
-    response.message = 'This endpoint has been deprecated. You no longer have to call /login before accessing a wallet.';
-    return response;
-  };
-  return this.cache.login(guid, options).then(addDeprecationWarning);
-};
-
 MerchantAPI.prototype.getWallet = function (guid, options) {
   return this.cache.getWallet(guid, options);
 };
@@ -23,6 +15,15 @@ MerchantAPI.prototype.getWalletHD = function (guid, options) {
   return this.cache.getWallet(guid, options).then(function (wallet) {
     return wallet.isUpgradedToHD ? wallet.hdwallet : q.reject('ERR_NO_HD');
   });
+};
+
+MerchantAPI.prototype.login = function (guid, options) {
+  var successResponse = {
+    guid: guid,
+    success: true,
+    message: 'This endpoint has been deprecated. You no longer have to call /login before accessing a wallet.'
+  };
+  return this.getWallet(guid, options).then(function () { return successResponse; });
 };
 
 MerchantAPI.prototype.getBalance = function (guid, options) {


### PR DESCRIPTION
Previously, if two requests to a single (not currently in-memory) wallet happened at the same time, one would error out with ERR_LOGIN_BUSY. This changes it so that instead of responding with an error, the service will retry the call a few times (with a delay between each try).