### PR TITLE
Correctly clear require cache on Windows

### DIFF
--- a/src/wallet-cache.js
+++ b/src/wallet-cache.js
@@ -74,13 +74,12 @@ WalletCache.prototype.getWallet = function (guid, options) {
 module.exports = WalletCache
 
 function generateInstance () {
+  var walletModule = 'blockchain-wallet-client-prebuilt'
+  var walletModuleR = new RegExp(walletModule + '.(index|src)')
   Object.keys(require.cache)
-    .filter(function (module) {
-      return (module.indexOf('blockchain-wallet-client-prebuilt/index') > -1 ||
-              module.indexOf('blockchain-wallet-client-prebuilt/src') > -1)
-    })
-    .forEach(function (module) { require.cache[module] = undefined })
-  return require('blockchain-wallet-client-prebuilt')
+    .filter(function (m) { return walletModuleR.test(m) })
+    .forEach(function (m) { delete require.cache[m] })
+  return require(walletModule)
 }
 
 function walletFromInstance (maybePw, instance) {


### PR DESCRIPTION
Issue thread: https://github.com/blockchain/service-my-wallet-v3/issues/164

_Problem_
The require cache wasn't getting cleared correctly on Windows because I was using a `'/'` in the path when testing for which modules to clear, but Windows uses `'\'` in paths. So the same wallet object would be imported every time, but after being initialized once it would silently fail [here](https://github.com/blockchain/My-Wallet-V3/blob/master/src/wallet.js#L324), causing the service to wait until the timeout triggered an error response.

_Solution_
Now it uses a regular expression to test for which modules to clear. The reason I'm checking for `index|src` is because otherwise `node_modules` would get cleared as well, which is unnecessary and would be wasteful.