### PR TITLE
Fee/byte param

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -127,9 +127,14 @@ MerchantAPI.prototype.makePayment = function (guid, options) {
       function error (e) {
         var msg = e.error
         if (msg === 'NO_UNSPENT_OUTPUTS') {
-          var have = satoshiToBTC(e.payment.balance)
-          var need = satoshiToBTC(e.payment.amounts.reduce(add, isNaN(options.fee) ? 10000 : options.fee))
-          msg = 'Insufficient funds. Value Needed ' + need + 'BTC. Available amount ' + have + 'BTC'
+          var p = e.payment
+          msg = {
+            error: 'Insufficient funds',
+            available: satoshiToBTC(p.balance),
+            needed: satoshiToBTC(p.amounts.reduce(add, p.balance - p.sweepAmount)),
+            sweep_amount_satoshi: p.sweepAmount,
+            sweep_fee_satoshi: p.sweepFee
+          }
         }
         return q.reject(msg || 'ERR_PUSHTX')
       }

--- a/src/api.js
+++ b/src/api.js
@@ -86,7 +86,23 @@ MerchantAPI.prototype.makePayment = function (guid, options) {
         .to(options.to)
         .amount(options.amount)
         .from(from)
-        .fee(isNaN(options.fee) ? 10000 : options.fee)
+
+      var warning
+      if (!isNaN(options.fee_per_byte)) {
+        if (options.fee_per_byte < 50) {
+          warning = 'Setting a fee_per_byte value below 50 satoshi/byte is not recommended, and may lead to long confirmation times'
+        }
+        payment.then(function (paymentObject) {
+          paymentObject.feePerKb = feePerByteToFeePerKb(options.fee_per_byte)
+          return paymentObject
+        }).prebuild()
+      } else if (!isNaN(options.fee)) {
+        warning = 'Using a static fee amount may cause large transactions to confirm slowly'
+        payment.fee(options.fee)
+      } else {
+        warning = 'It is recommended to specify a custom fee using the fee_per_byte parameter, transactions using the default 10000 satoshi fee may not confirm'
+        payment.fee(10000)
+      }
 
       var password
       if (wallet.isDoubleEncrypted) password = options.second_password
@@ -103,7 +119,8 @@ MerchantAPI.prototype.makePayment = function (guid, options) {
           txid: tx.txid,
           tx_hash: tx.txid,
           message: message,
-          success: true
+          success: true,
+          warning: warning
         }
       }
 
@@ -287,4 +304,8 @@ function add (total, next) {
 
 function satoshiToBTC (satoshi) {
   return parseFloat((satoshi / SATOSHI_PER_BTC).toFixed(8))
+}
+
+function feePerByteToFeePerKb (feePerByte) {
+  return Math.floor(feePerByte * 1000)
 }

--- a/src/server.js
+++ b/src/server.js
@@ -44,6 +44,7 @@ legacyAPI.use(parseOptions({
   from: String,
   label: String,
   recipients: Identity,
+  fee_per_byte: Number,
   second_password: String,
   amount: Number,
   fee: Number,

--- a/src/server.js
+++ b/src/server.js
@@ -226,22 +226,18 @@ function handleResponse (apiAction, res, errCode) {
   apiAction
     .then(function (data) { res.status(200).json(data) })
     .catch(function (e) {
-      winston.error(e)
-      var err = ecodes[e] || ecodes['ERR_UNEXPECT']
-      if (stringContains(e, 'Insufficient funds. Value Needed')) {
-        var rgx = /Insufficient funds. Value Needed ([^]+)BTC. Available amount ([^]+)BTC/
-        var errData = e.match(rgx)
-        return res.status(400).json({
-          error: 'Insufficient funds',
-          needed: errData ? parseFloat(errData[1]) : undefined,
-          available: errData ? parseFloat(errData[2]) : undefined
-        })
+      if (typeof e === 'object') {
+        winston.error(e.error, e)
+        res.status(errCode || 500).json(e)
+      } else {
+        winston.error(e)
+        var err = ecodes[e] || ecodes['ERR_UNEXPECT']
+        if (
+          stringContains(e, 'Missing query parameter') ||
+          stringContains(e, 'Error Decrypting Wallet')
+        ) err = e
+        res.status(errCode || 500).json({ error: err })
       }
-      if (
-        stringContains(e, 'Missing query parameter') ||
-        stringContains(e, 'Error Decrypting Wallet')
-      ) err = e
-      res.status(errCode || 500).json({ error: err })
     })
 }
 


### PR DESCRIPTION
- Adds option to specify satoshi/byte, rather than an absolute fee
- Warning messages for certain fee amounts
- Fee error response now includes sweep info, probably useful for some users
- Backwards compatible

Todo: Add automatic fee calculation (will do once new fee endpoint is live).