### PR TITLE
Readme V2 changed to V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Blockchain Wallet API V2
+# Blockchain Wallet API V3
 
 Programmatically interface with your Blockchain.info wallet.
 


### PR DESCRIPTION
Heading in readme had a typo wich still reffered v2, changed to v3